### PR TITLE
Fix link to breachable offences in reporting guide.

### DIFF
--- a/docs/reporting-a-player.md
+++ b/docs/reporting-a-player.md
@@ -1,6 +1,6 @@
 # Reporting a Player
 
-Before reporting a player, please familiarise yourself with the breachable offences [in-game](https://ngmc.co/vacancies) and on [Discord](https://support.nethergames.org/discord-server-regulations.html).
+Before reporting a player, please familiarise yourself with the breachable offences [in-game](https://support.nethergames.org/enforcement-system) and on [Discord](https://support.nethergames.org/discord-server-regulations.html).
 
 You can report a player by following these steps:
 


### PR DESCRIPTION
Previous link was redirecting to the Jobs page. Changed it to the Enforcement System page.